### PR TITLE
Add basic game account marketplace pages

### DIFF
--- a/src/app/accounts/[id]/page.js
+++ b/src/app/accounts/[id]/page.js
@@ -1,0 +1,26 @@
+import Link from "next/link";
+import { getAccount } from "../../../data/accounts";
+
+export default function AccountPage({ params }) {
+  const account = getAccount(params.id);
+
+  if (!account) {
+    return <main className="p-8">Account not found.</main>;
+  }
+
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold mb-2">{account.game}</h1>
+      <p className="mb-2">{account.description}</p>
+      <p className="font-bold mb-4">${account.price}</p>
+      <button className="bg-blue-600 text-white px-4 py-2 rounded">
+        Buy now
+      </button>
+      <div className="mt-4">
+        <Link href="/" className="text-blue-600 hover:underline">
+          ← Back to listings
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,103 +1,15 @@
-import Image from "next/image";
+import AccountCard from "../components/AccountCard";
+import { accounts } from "../data/accounts";
 
 export default function Home() {
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              src/app/page.js
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+    <main className="p-8">
+      <h1 className="text-3xl font-bold mb-6 text-center">Game Account Marketplace</h1>
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {accounts.map((account) => (
+          <AccountCard key={account.id} account={account} />
+        ))}
+      </div>
+    </main>
   );
 }

--- a/src/components/AccountCard.js
+++ b/src/components/AccountCard.js
@@ -1,0 +1,17 @@
+import Link from "next/link";
+
+export default function AccountCard({ account }) {
+  return (
+    <div className="border rounded p-4 shadow-sm">
+      <h2 className="text-xl font-semibold">{account.game}</h2>
+      <p className="text-sm text-gray-700 mt-1">{account.description}</p>
+      <p className="font-bold mt-4">${account.price}</p>
+      <Link
+        href={`/accounts/${account.id}`}
+        className="mt-4 inline-block text-blue-600 hover:underline"
+      >
+        View details
+      </Link>
+    </div>
+  );
+}

--- a/src/data/accounts.js
+++ b/src/data/accounts.js
@@ -1,0 +1,24 @@
+export const accounts = [
+  {
+    id: "1",
+    game: "Valorant",
+    description: "Radiant rank account with premium skins",
+    price: 150,
+  },
+  {
+    id: "2",
+    game: "Genshin Impact",
+    description: "AR 55 with rare five-star characters",
+    price: 200,
+  },
+  {
+    id: "3",
+    game: "Mobile Legends",
+    description: "Mythic glory account, all heroes unlocked",
+    price: 120,
+  },
+];
+
+export function getAccount(id) {
+  return accounts.find((acc) => acc.id === id);
+}


### PR DESCRIPTION
## Summary
- add sample account data and helper
- create account card component and dynamic account pages
- replace default home page with game account listings

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires ESLint setup; installation blocked)


------
https://chatgpt.com/codex/tasks/task_e_6895bc3b46ac8323b5ed69f89bbaae3e